### PR TITLE
Fix missing return in BaseRepository

### DIFF
--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -119,7 +119,7 @@ class BaseRepository {
     foreach ($criteria as $property => $value) {
       $qb->where($property, $value, '=');
     }
-    $qb->orderBy('ID', 'ASC')
+    return $qb->orderBy('ID', 'ASC')
       ->buildQuery()
       ->getResults();
   }


### PR DESCRIPTION
Method `findBy` of class `BaseRepository` was missing the return of the results